### PR TITLE
Greg Fleishman - 4 repos: CircuitSeeker, BigStream, FishSpot, Cluster…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md).
 
 *Image processing in the Dask/Python ecosystem*
 
+* [ClusterWrap](https://github.com/GFleishman/ClusterWrap) - Library for running Dask on the Janelia cluster
 * [dask-janelia](https://github.com/JaneliaSciComp/dask-janelia) - Library for running Dask on the Janelia cluster
 * [xarray-multiscale](https://github.com/JaneliaSciComp/xarray-multiscale) - Library for generating multiscale pyramids with Dask
 
@@ -55,6 +56,9 @@ Please read the [contribution guidelines](CONTRIBUTING.md).
 
 *Scientific applications with GUIs and user manuals*
 
+* [BigStream](https://github.com/GFleishman/bigstream) - Distributed piecewise affine and deformable alignment for big 3D datasets
+* [CircuitSeeker](https://github.com/GFleishman/CircuitSeeker) - Distributed complex alignment tasks for big 4D datasets
+* [FishSpot](https://github.com/GFleishman/fishspot) - Fully automated PSF estimation and spot detection for punctate data (e.g. FISH spots)
 * [HippoSeq](https://hipposeq.janelia.org) - Interactive analysis tool for RNA-seq data in the mouse hippocampus
 * [Janelia Workstation](https://github.com/JaneliaSciComp/workstation) - Discovery platform supporting the FlyLight and MouseLight projects
 * [neuPrint+](https://neuprint.janelia.org) - Analysis tools for connectomics


### PR DESCRIPTION
Hi Konrad,

ClusterWrap is similar but different to dask-janelia. ClusterWrap is more object oriented and uses adaptive cluster scaling (dask decides the cluster size dynamically while executing a task graph) whereas dask-janelia is more functional in design and uses fixed cluster sizes. I think both are instructive and useful for new users interested in dask.

BigStream has it's own nice looking readme but needs updating.

CircuitSeeker and FishSpot have very little documentation which is on my TODO list - but there is a lot of value in the code and they should be included.

Thanks,
Greg